### PR TITLE
fix(loom): validate prerequisite graph is a DAG, break cycles at the weakest link

### DIFF
--- a/apps/api/services/loom_extraction.py
+++ b/apps/api/services/loom_extraction.py
@@ -347,6 +347,7 @@ async def extract_course_concepts(
                 break
 
     # Create edges
+    prereq_edges: list[KnowledgeEdge] = []
     for item in concepts_data[:max_nodes]:
         name = (item.get("name") or "").strip().lower()
         source = node_by_name.get(name)
@@ -362,6 +363,7 @@ async def extract_course_concepts(
                     relation_type="prerequisite",
                 )
                 db.add(edge)
+                prereq_edges.append(edge)
 
         for related_name in item.get("related", []):
             target = node_by_name.get(related_name.strip().lower())
@@ -372,6 +374,27 @@ async def extract_course_concepts(
                     relation_type="related",
                 )
                 db.add(edge)
+
+    # Validate the just-inserted prerequisite edges form a DAG — LLM-extracted
+    # prerequisites can be circular (A requires B, B requires A), which would
+    # hang learning path generation and mastery propagation downstream.
+    if prereq_edges:
+        from services.loom_graph import resolve_prerequisite_cycles
+        cycles, broken = resolve_prerequisite_cycles(
+            {n.id for n in nodes}, prereq_edges,
+        )
+        for edge in broken:
+            db.expunge(edge)
+        if broken:
+            node_name_by_id = {n.id: n.name for n in nodes}
+            logger.warning(
+                "Broke %d circular prerequisite link(s) for course %s: %s",
+                len(broken), course_id,
+                [
+                    f"{node_name_by_id.get(e.source_id)} -> {node_name_by_id.get(e.target_id)}"
+                    for e in broken
+                ],
+            )
 
     await db.commit()
     logger.info("Extracted %d concept nodes for course %s (after fusion)", len(nodes), course_id)

--- a/apps/api/services/loom_graph.py
+++ b/apps/api/services/loom_graph.py
@@ -231,6 +231,155 @@ async def check_prerequisites_satisfied(
     return (len(gaps) == 0, gaps)
 
 
+# ── DAG Validation ──
+
+def _find_cycle(
+    node_ids: set[uuid.UUID],
+    edge_pairs: list[tuple[uuid.UUID, uuid.UUID]],
+) -> list[uuid.UUID] | None:
+    """Find one prerequisite cycle, or None if the graph is a DAG.
+
+    Kahn's algorithm peels off acyclic nodes; any unpeeled remainder must
+    contain a cycle. Every remainder node keeps at least one incoming edge
+    from the remainder, so walking predecessors from any remainder node is
+    guaranteed to revisit a node — that revisited loop is the cycle, returned
+    in edge order (A -> B -> C -> A yields [A, B, C]).
+    """
+    adj: dict[uuid.UUID, list[uuid.UUID]] = {nid: [] for nid in node_ids}
+    in_degree: dict[uuid.UUID, int] = {nid: 0 for nid in node_ids}
+    for source, target in edge_pairs:
+        if source in node_ids and target in node_ids:
+            adj[source].append(target)
+            in_degree[target] += 1
+
+    queue: deque[uuid.UUID] = deque(nid for nid in node_ids if in_degree[nid] == 0)
+    peeled = 0
+    while queue:
+        nid = queue.popleft()
+        peeled += 1
+        for neighbor in adj[nid]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if peeled == len(node_ids):
+        return None
+
+    remainder = {nid for nid in node_ids if in_degree[nid] > 0}
+    rev: dict[uuid.UUID, list[uuid.UUID]] = {nid: [] for nid in remainder}
+    for source, target in edge_pairs:
+        if source in remainder and target in remainder:
+            rev[target].append(source)
+
+    path: list[uuid.UUID] = []
+    index_in_path: dict[uuid.UUID, int] = {}
+    current = next(iter(remainder))
+    while current not in index_in_path:
+        index_in_path[current] = len(path)
+        path.append(current)
+        current = rev[current][0]
+    cycle = path[index_in_path[current]:]
+    cycle.reverse()
+    return cycle
+
+
+def resolve_prerequisite_cycles(
+    node_ids: set[uuid.UUID],
+    edges: list,
+) -> tuple[list[list[uuid.UUID]], list]:
+    """Detect prerequisite cycles and pick each cycle's weakest edge for removal.
+
+    Repeatedly finds a cycle and drops its lowest-weight edge (the
+    least-confidence link) until the graph is acyclic. Edges only need
+    ``source_id``/``target_id``/``weight`` attributes; an unset weight
+    counts as the column default 1.0.
+
+    Returns ``(cycles, to_remove)``: cycles as node-ID lists in edge order,
+    and the edge objects whose removal makes the graph a DAG.
+    """
+    working = list(edges)
+    cycles: list[list[uuid.UUID]] = []
+    to_remove: list = []
+    while True:
+        cycle = _find_cycle(node_ids, [(e.source_id, e.target_id) for e in working])
+        if cycle is None:
+            return cycles, to_remove
+        cycles.append(cycle)
+        cycle_pairs = set(zip(cycle, cycle[1:] + cycle[:1]))
+        cycle_edges = [e for e in working if (e.source_id, e.target_id) in cycle_pairs]
+        weakest = min(
+            cycle_edges,
+            key=lambda e: e.weight if e.weight is not None else 1.0,
+        )
+        working.remove(weakest)
+        to_remove.append(weakest)
+
+
+async def validate_graph(
+    db: AsyncSession,
+    course_id: uuid.UUID,
+    repair: bool = False,
+) -> dict:
+    """Validate that a course's prerequisite edges form a DAG.
+
+    Circular prerequisites (A requires B, B requires C, C requires A) cause
+    infinite loops in learning path generation and mastery propagation, so
+    cycles are detected via topological sort. With ``repair=True``, each
+    cycle is broken by deleting its lowest-weight edge.
+
+    Returns::
+
+        {
+            "is_dag": bool,           # True if no cycles were found
+            "cycles": [[name, ...]],  # concept names per detected cycle
+            # Deleted (repair=True) or proposed for deletion (repair=False):
+            "removed_edges": [{"source": ..., "target": ..., "weight": ...}],
+        }
+    """
+    nodes_result = await db.execute(
+        select(KnowledgeNode).where(KnowledgeNode.course_id == course_id)
+    )
+    nodes = nodes_result.scalars().all()
+    if not nodes:
+        return {"is_dag": True, "cycles": [], "removed_edges": []}
+
+    node_by_id = {n.id: n for n in nodes}
+
+    edges_result = await db.execute(
+        select(KnowledgeEdge).where(
+            KnowledgeEdge.source_id.in_(list(node_by_id)),
+            KnowledgeEdge.relation_type == "prerequisite",
+        )
+    )
+    edges = list(edges_result.scalars().all())
+
+    cycles, to_remove = resolve_prerequisite_cycles(set(node_by_id), edges)
+    removed = [
+        {
+            "source": node_by_id[e.source_id].name,
+            "target": node_by_id[e.target_id].name,
+            "weight": e.weight if e.weight is not None else 1.0,
+        }
+        for e in to_remove
+    ]
+
+    if repair and to_remove:
+        for edge in to_remove:
+            await db.delete(edge)
+        await db.flush()
+        logger.warning(
+            "Broke %d circular prerequisite link(s) for course %s: %s",
+            len(to_remove), course_id,
+            ["{} -> {}".format(r["source"], r["target"]) for r in removed],
+        )
+
+    return {
+        "is_dag": not cycles,
+        "cycles": [[node_by_id[nid].name for nid in cycle] for cycle in cycles],
+        "removed_edges": removed,
+    }
+
+
 # ── Learning Path Generation ──
 
 async def generate_learning_path(

--- a/tests/test_loom_validation.py
+++ b/tests/test_loom_validation.py
@@ -1,0 +1,238 @@
+"""Tests for LOOM knowledge graph DAG validation (cycle detection + repair)."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.knowledge_graph import KnowledgeNode
+from services.loom_extraction import extract_course_concepts
+from services.loom_graph import (
+    _find_cycle,
+    resolve_prerequisite_cycles,
+    validate_graph,
+)
+
+
+def _ids(n):
+    return [uuid.uuid4() for _ in range(n)]
+
+
+def _edge(src, tgt, weight=1.0):
+    e = MagicMock()
+    e.source_id = src
+    e.target_id = tgt
+    e.relation_type = "prerequisite"
+    e.weight = weight
+    return e
+
+
+def _node(name, nid):
+    n = MagicMock()
+    n.id = nid
+    n.name = name
+    return n
+
+
+def _scalars(items):
+    s = MagicMock(); s.all.return_value = items
+    r = MagicMock(); r.scalars.return_value = s
+    return r
+
+
+# ── _find_cycle ──
+
+def test_find_cycle_returns_none_for_dag():
+    a, b, c = _ids(3)
+    assert _find_cycle({a, b, c}, [(a, b), (b, c)]) is None
+
+
+def test_find_cycle_returns_none_for_empty_graph():
+    assert _find_cycle(set(), []) is None
+
+
+def test_find_cycle_detects_triangle():
+    a, b, c = _ids(3)
+    cycle = _find_cycle({a, b, c}, [(a, b), (b, c), (c, a)])
+    assert cycle is not None
+    assert set(cycle) == {a, b, c}
+    # Cycle is returned in edge order: each consecutive pair is a real edge
+    pairs = set(zip(cycle, cycle[1:] + cycle[:1]))
+    assert pairs <= {(a, b), (b, c), (c, a)}
+
+
+def test_find_cycle_detects_self_loop():
+    a, b = _ids(2)
+    cycle = _find_cycle({a, b}, [(a, a), (a, b)])
+    assert cycle == [a]
+
+
+def test_find_cycle_ignores_acyclic_tail():
+    # Triangle a->b->c->a plus a tail c->d: d is downstream of the cycle and
+    # never peels, but the extracted cycle must not include it.
+    a, b, c, d = _ids(4)
+    cycle = _find_cycle({a, b, c, d}, [(a, b), (b, c), (c, a), (c, d)])
+    assert cycle is not None
+    assert set(cycle) == {a, b, c}
+
+
+def test_find_cycle_ignores_edges_outside_node_set():
+    a, b = _ids(2)
+    ghost = uuid.uuid4()
+    assert _find_cycle({a, b}, [(a, b), (b, ghost), (ghost, a)]) is None
+
+
+# ── resolve_prerequisite_cycles ──
+
+def test_resolve_returns_empty_for_dag():
+    a, b, c = _ids(3)
+    edges = [_edge(a, b), _edge(b, c)]
+    cycles, to_remove = resolve_prerequisite_cycles({a, b, c}, edges)
+    assert cycles == [] and to_remove == []
+
+
+def test_resolve_breaks_weakest_link():
+    a, b, c = _ids(3)
+    weak = _edge(b, c, weight=0.3)
+    edges = [_edge(a, b, weight=1.0), weak, _edge(c, a, weight=0.9)]
+    cycles, to_remove = resolve_prerequisite_cycles({a, b, c}, edges)
+    assert len(cycles) == 1 and set(cycles[0]) == {a, b, c}
+    assert to_remove == [weak]
+
+
+def test_resolve_treats_none_weight_as_default():
+    # Pending (unflushed) edges have weight=None; the column default is 1.0,
+    # so an explicit lower weight must lose to a None weight.
+    a, b = _ids(2)
+    weak = _edge(a, b, weight=0.5)
+    pending = _edge(b, a, weight=None)
+    cycles, to_remove = resolve_prerequisite_cycles({a, b}, [pending, weak])
+    assert len(cycles) == 1
+    assert to_remove == [weak]
+
+
+def test_resolve_breaks_multiple_independent_cycles():
+    a, b, c, d = _ids(4)
+    weak1 = _edge(b, a, weight=0.1)
+    weak2 = _edge(d, c, weight=0.2)
+    edges = [_edge(a, b), weak1, _edge(c, d), weak2]
+    cycles, to_remove = resolve_prerequisite_cycles({a, b, c, d}, edges)
+    assert len(cycles) == 2
+    assert set(to_remove) == {weak1, weak2}
+
+
+def test_resolve_does_not_mutate_input():
+    a, b = _ids(2)
+    edges = [_edge(a, b), _edge(b, a)]
+    resolve_prerequisite_cycles({a, b}, edges)
+    assert len(edges) == 2
+
+
+# ── validate_graph ──
+
+@pytest.mark.asyncio
+async def test_validate_graph_empty_course_is_dag():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([])])
+    result = await validate_graph(db, uuid.uuid4())
+    assert result == {"is_dag": True, "cycles": [], "removed_edges": []}
+
+
+@pytest.mark.asyncio
+async def test_validate_graph_acyclic():
+    aid, bid = _ids(2)
+    nodes = [_node("Limit", aid), _node("Derivative", bid)]
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars(nodes), _scalars([_edge(bid, aid)])])
+    result = await validate_graph(db, uuid.uuid4())
+    assert result["is_dag"] is True
+    assert result["cycles"] == [] and result["removed_edges"] == []
+
+
+@pytest.mark.asyncio
+async def test_validate_graph_detects_cycle_without_repair():
+    aid, bid, cid_ = _ids(3)
+    nodes = [_node("A", aid), _node("B", bid), _node("C", cid_)]
+    edges = [_edge(aid, bid), _edge(bid, cid_), _edge(cid_, aid, weight=0.2)]
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars(nodes), _scalars(edges)])
+    db.delete = AsyncMock(); db.flush = AsyncMock()
+    result = await validate_graph(db, uuid.uuid4())
+    assert result["is_dag"] is False
+    assert sorted(result["cycles"][0]) == ["A", "B", "C"]
+    assert result["removed_edges"] == [{"source": "C", "target": "A", "weight": 0.2}]
+    db.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_validate_graph_repair_deletes_weakest_edge():
+    aid, bid = _ids(2)
+    nodes = [_node("A", aid), _node("B", bid)]
+    weak = _edge(bid, aid, weight=0.4)
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars(nodes), _scalars([_edge(aid, bid), weak])])
+    db.delete = AsyncMock(); db.flush = AsyncMock()
+    result = await validate_graph(db, uuid.uuid4(), repair=True)
+    assert result["is_dag"] is False
+    db.delete.assert_awaited_once_with(weak)
+    db.flush.assert_awaited()
+
+
+# ── extraction integration: cycles broken before commit ──
+
+@pytest.mark.asyncio
+async def test_extract_breaks_circular_prerequisites():
+    db = AsyncMock(); cid = uuid.uuid4()
+    cn = MagicMock(); cn.content = "A" * 300; cn.title = "Calc"
+    resp = ('[{"name":"Limit","description":"x","prerequisites":["Derivative"],"related":[],"bloom_level":"understand"},'
+            '{"name":"Derivative","description":"y","prerequisites":["Limit"],"related":[],"bloom_level":"apply"}]')
+
+    def _scalar(v):
+        r = MagicMock(); r.scalar.return_value = v; return r
+
+    db.execute = AsyncMock(side_effect=[_scalar(0), _scalars([cn])])
+
+    # Real KnowledgeNode ids are only assigned at flush; the mocked flush
+    # never runs the ORM, so assign ids at add-time to let edges be created.
+    def _assign_id(obj):
+        if isinstance(obj, KnowledgeNode) and obj.id is None:
+            obj.id = uuid.uuid4()
+
+    db.add = MagicMock(side_effect=_assign_id)
+    db.expunge = MagicMock()
+    db.flush = AsyncMock(); db.commit = AsyncMock()
+    mc = AsyncMock(); mc.extract = AsyncMock(return_value=(resp, {}))
+    with patch("services.llm.router.get_llm_client", return_value=mc):
+        result = await extract_course_concepts(db, cid)
+
+    assert len(result) == 2
+    # The two-node cycle (Limit <-> Derivative) must be broken by dropping one edge
+    assert db.expunge.call_count == 1
+    dropped = db.expunge.call_args[0][0]
+    assert dropped.relation_type == "prerequisite"
+
+
+@pytest.mark.asyncio
+async def test_extract_keeps_acyclic_prerequisites():
+    db = AsyncMock(); cid = uuid.uuid4()
+    cn = MagicMock(); cn.content = "A" * 300; cn.title = "Calc"
+    resp = ('[{"name":"Limit","description":"x","prerequisites":[],"related":[],"bloom_level":"understand"},'
+            '{"name":"Derivative","description":"y","prerequisites":["Limit"],"related":[],"bloom_level":"apply"}]')
+
+    def _scalar(v):
+        r = MagicMock(); r.scalar.return_value = v; return r
+
+    db.execute = AsyncMock(side_effect=[_scalar(0), _scalars([cn])])
+
+    def _assign_id(obj):
+        if isinstance(obj, KnowledgeNode) and obj.id is None:
+            obj.id = uuid.uuid4()
+
+    db.add = MagicMock(side_effect=_assign_id)
+    db.expunge = MagicMock()
+    db.flush = AsyncMock(); db.commit = AsyncMock()
+    mc = AsyncMock(); mc.extract = AsyncMock(return_value=(resp, {}))
+    with patch("services.llm.router.get_llm_client", return_value=mc):
+        result = await extract_course_concepts(db, cid)
+
+    assert len(result) == 2
+    db.expunge.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #34.

LLM-extracted prerequisites can be circular (A requires B, B requires C, C requires A). Nothing validated the graph after edge insertion, so cycles reached the database and caused infinite loops in learning path generation and mastery propagation.

## Changes

- **`loom_graph.py` — `validate_graph(db, course_id, repair=False)`**: detects cycles in a course's prerequisite edges via topological sort (Kahn's algorithm) and reports them as concept-name lists. With `repair=True` it breaks each cycle by deleting its lowest-weight edge (the least-confidence link, per the issue's "break the weakest link" option) until the graph is acyclic.
- **`loom_graph.py` — `resolve_prerequisite_cycles(node_ids, edges)`**: pure helper shared by `validate_graph` and the extraction path; iteratively finds a cycle and selects its weakest edge for removal. Unset weights count as the column default 1.0.
- **`loom_extraction.py`**: cycle resolution now runs in `extract_course_concepts()` right after the prerequisite edges are inserted into the session. Offending edges are expunged before commit, so a cyclic graph never reaches the database. Broken links are logged with concept names.

## Design notes

- Cycle extraction walks predecessors over the un-peeled remainder of Kahn's algorithm, so it returns a concrete cycle (not just "a cycle exists") and never includes acyclic tail nodes hanging off a cycle.
- The extraction hook works on the in-memory edge list (no extra queries), so it adds zero DB round-trips to the ingestion path.
- Conversation graph sync (`knowledge/graph_ops.py`) can also insert `prerequisite` edges; wiring `validate_graph(repair=True)` there is left as a follow-up to keep this PR scoped to the issue.

## Tests

17 new tests in `tests/test_loom_validation.py`:

- `_find_cycle`: DAG, empty graph, triangle, self-loop, cycle with acyclic tail, edges outside the node set
- `resolve_prerequisite_cycles`: weakest-link selection, None-weight default handling, multiple independent cycles, input not mutated
- `validate_graph`: empty course, acyclic, cycle report without repair, repair deletes exactly the weakest edge
- extraction integration: circular prerequisites are broken before commit; acyclic prerequisites untouched

`tests/test_loom_validation.py` + `tests/test_loom.py`: **54 passed** locally.

## Acceptance criteria

- [x] `validate_graph()` function detects cycles
- [x] Cycle detection is called after edge insertion
- [x] Unit test with a known cyclic graph verifies detection
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
