### PR TITLE
feat(lector): configurable interference threshold, consolidation on review outcomes, E2E coverage

### DIFF
--- a/apps/api/services/lector.py
+++ b/apps/api/services/lector.py
@@ -92,6 +92,7 @@ async def get_smart_review_session(
     prereqs_of: dict[uuid.UUID, list[uuid.UUID]] = {}  # concept → its prerequisites
     related_to: dict[uuid.UUID, list[uuid.UUID]] = {}
     confused_with: dict[uuid.UUID, list[uuid.UUID]] = {}
+    max_confused_weight: dict[uuid.UUID, float] = {}  # concept → strongest interference edge
 
     for edge in edges:
         if edge.relation_type == "prerequisite":
@@ -100,6 +101,9 @@ async def get_smart_review_session(
             related_to.setdefault(edge.source_id, []).append(edge.target_id)
         elif edge.relation_type == "confused_with":
             confused_with.setdefault(edge.source_id, []).append(edge.target_id)
+            weight = edge.weight if edge.weight is not None else 1.0
+            if weight > max_confused_weight.get(edge.source_id, 0.0):
+                max_confused_weight[edge.source_id] = weight
 
     # Score each concept
     now = datetime.now(timezone.utc)
@@ -157,14 +161,8 @@ async def get_smart_review_session(
         # Boost priority for concepts with high-weight confused_with edges,
         # regardless of whether the confused concept has low mastery.
         # This catches potential confusion BEFORE the student makes a mistake.
-        max_interference = 0.0
-        for confused_id in confused_with.get(node.id, []):
-            for edge in edges:
-                if (edge.source_id == node.id and edge.target_id == confused_id
-                        and edge.relation_type == "confused_with"
-                        and edge.weight > max_interference):
-                    max_interference = edge.weight
-        if max_interference > 0.6:
+        max_interference = max_confused_weight.get(node.id, 0.0)
+        if max_interference > settings.loom_interference_similarity_threshold:
             interference_boost = max_interference * settings.lector_factor_interference
             priority += interference_boost
             reason_parts.append("high semantic interference")
@@ -335,6 +333,17 @@ async def record_review_outcome(
     else:
         mastery.wrong_count += 1
         mastery.mastery_score = max(0.0, mastery.mastery_score - 0.1)
+
+    # Consolidation bonus: review outcomes count toward prerequisite-group
+    # mastery just like quiz submissions do (update_concept_mastery path),
+    # so a recall that completes a mastered prereq group boosts the parent.
+    node_result = await db.execute(
+        select(KnowledgeNode).where(KnowledgeNode.id == concept_id)
+    )
+    node = node_result.scalar_one_or_none()
+    if node:
+        from services.loom_mastery import _consolidate_mastered_concepts
+        await _consolidate_mastered_concepts(db, user_id, node.course_id, concept_id)
 
     await db.flush()
     logger.info(

--- a/tests/test_lector.py
+++ b/tests/test_lector.py
@@ -34,7 +34,7 @@ _LECTOR_DEFAULTS = dict(
     lector_factor_never_practiced=0.3, lector_factor_time_decay=0.3,
     lector_factor_prerequisite=0.2, lector_factor_confusion=0.1,
     lector_prerequisite_threshold=0.5, lector_confusion_threshold=0.6,
-    lector_factor_interference=0.15,
+    lector_factor_interference=0.15, loom_interference_similarity_threshold=0.6,
 )
 
 
@@ -229,7 +229,7 @@ async def test_outcome_correct():
     past = datetime.now(timezone.utc) - timedelta(days=5)
     m = _mastery(uid, cid, score=0.5, pcount=3, stab=5.0, cc=2, wc=1, last=past)
     n = _node(_uid(), "T")
-    db = _mock_db([[m], [n]])
+    db = _mock_db([[m], [n], []])
     await record_review_outcome(db, uid, cid, recalled_correctly=True)
     assert m.practice_count == 4 and m.correct_count == 3
     assert m.mastery_score > 0.5 and m.stability_days > 5.0
@@ -241,7 +241,7 @@ async def test_outcome_incorrect():
     uid, cid = _uid(), _uid()
     past = datetime.now(timezone.utc) - timedelta(days=5)
     m = _mastery(uid, cid, score=0.6, pcount=5, stab=10.0, cc=4, wc=1, last=past)
-    db = _mock_db([[m], [_node(_uid(), "T")]])
+    db = _mock_db([[m], [_node(_uid(), "T")], []])
     await record_review_outcome(db, uid, cid, recalled_correctly=False)
     assert m.wrong_count == 2 and m.mastery_score == pytest.approx(0.5, abs=0.01)
     assert m.stability_days < 10.0
@@ -259,11 +259,11 @@ async def test_outcome_missing_mastery():
 async def test_outcome_bounds():
     uid, cid = _uid(), _uid()
     mh = _mastery(uid, cid, score=0.99, pcount=10, stab=5.0, cc=9, wc=1)
-    db = _mock_db([[mh], [_node(_uid(), "T")]])
+    db = _mock_db([[mh], [_node(_uid(), "T")], []])
     await record_review_outcome(db, uid, cid, recalled_correctly=True)
     assert mh.mastery_score <= 1.0
     ml = _mastery(uid, cid, score=0.05, pcount=10, stab=1.0, cc=1, wc=9)
-    db2 = _mock_db([[ml], [_node(_uid(), "T")]])
+    db2 = _mock_db([[ml], [_node(_uid(), "T")], []])
     await record_review_outcome(db2, uid, cid, recalled_correctly=False)
     assert ml.mastery_score >= 0.0
 

--- a/tests/test_lector_e2e.py
+++ b/tests/test_lector_e2e.py
@@ -1,0 +1,208 @@
+"""E2E test — LECTOR semantic spaced review pipeline (issue #39 MVP).
+
+Simulates: practice → BKT mastery updates → smart review session, verifying
+review ordering, prerequisite-first gating, interference boost (configurable
+threshold), session structuring, and consolidation bonuses on review outcomes.
+
+Uses in-memory SQLite so no external DB is needed.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from database import Base
+from models.knowledge_graph import KnowledgeNode, KnowledgeEdge, ConceptMastery
+from services.lector import get_smart_review_session, record_review_outcome
+from services.lector_session import build_structured_session
+from services.loom_mastery import update_concept_mastery
+
+# ── Fixtures ──
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def user_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def course_id():
+    return uuid.uuid4()
+
+
+# ── Graph seeding ──
+
+
+async def _seed_graph(db: AsyncSession, course_id: uuid.UUID) -> dict[str, KnowledgeNode]:
+    """Limit ← Derivative ← Chain Rule prereq chain; Derivative ↔ Integral confusion."""
+    nodes = {}
+    for name, bloom in [("Limit", 2), ("Derivative", 3), ("Chain Rule", 3), ("Integral", 3)]:
+        node = KnowledgeNode(
+            id=uuid.uuid4(), course_id=course_id, name=name,
+            description=f"Concept: {name}",
+            metadata_={"bloom_level": bloom},
+        )
+        db.add(node)
+        nodes[name] = node
+    await db.flush()
+
+    db.add(KnowledgeEdge(source_id=nodes["Derivative"].id, target_id=nodes["Limit"].id,
+                         relation_type="prerequisite", weight=1.0))
+    db.add(KnowledgeEdge(source_id=nodes["Chain Rule"].id, target_id=nodes["Derivative"].id,
+                         relation_type="prerequisite", weight=1.0))
+    db.add(KnowledgeEdge(source_id=nodes["Derivative"].id, target_id=nodes["Integral"].id,
+                         relation_type="confused_with", weight=0.8))
+    await db.commit()
+    return nodes
+
+
+async def _practice(db, user_id, course_id, name, correct, times=1):
+    for _ in range(times):
+        await update_concept_mastery(
+            db, user_id, name, course_id, correct=correct, question_type="free_response",
+        )
+    await db.commit()
+
+
+# ── E2E: practice → mastery → review ordering ──
+
+
+@pytest.mark.asyncio
+async def test_e2e_practice_drives_review_ordering(db, user_id, course_id):
+    await _seed_graph(db, course_id)
+
+    # Limit mastered (4 strong correct answers), Derivative failing (2 wrong)
+    await _practice(db, user_id, course_id, "Limit", correct=True, times=4)
+    await _practice(db, user_id, course_id, "Derivative", correct=False, times=2)
+
+    items = await get_smart_review_session(db, user_id, course_id, max_items=10)
+    by_name = {i.concept_name: i for i in items}
+
+    # Chain Rule is most urgent: never practiced + gated by the weak Derivative
+    assert items[0].concept_name == "Chain Rule"
+    assert by_name["Chain Rule"].review_type == "prerequisite_first"
+    assert "prerequisite 'Derivative' is weak" in by_name["Chain Rule"].reason
+
+    # The failing concept is queued with its BKT-collapsed mastery
+    assert by_name["Derivative"].mastery < 0.3
+    assert by_name["Derivative"].priority > 0
+
+    # Its strong confusion edge (0.8 > default threshold 0.6) is flagged
+    assert "high semantic interference" in by_name["Derivative"].reason
+
+    # The mastered concept does not clutter the session
+    assert "Limit" not in by_name
+
+
+@pytest.mark.asyncio
+async def test_e2e_interference_threshold_is_configurable(db, user_id, course_id, monkeypatch):
+    from config import settings
+
+    await _seed_graph(db, course_id)
+    await _practice(db, user_id, course_id, "Derivative", correct=False, times=2)
+
+    # Raise the interference threshold above the edge weight (0.8): no boost
+    monkeypatch.setattr(settings, "loom_interference_similarity_threshold", 0.95)
+    items = await get_smart_review_session(db, user_id, course_id, max_items=10)
+    derivative = next(i for i in items if i.concept_name == "Derivative")
+    assert "high semantic interference" not in derivative.reason
+
+
+@pytest.mark.asyncio
+async def test_e2e_structured_session_preserves_items(db, user_id, course_id):
+    await _seed_graph(db, course_id)
+    await _practice(db, user_id, course_id, "Limit", correct=True, times=2)
+    await _practice(db, user_id, course_id, "Derivative", correct=False, times=2)
+
+    items = await get_smart_review_session(db, user_id, course_id, max_items=10)
+    structured = await build_structured_session(items, max_items=10)
+
+    assert len(structured) == len(items)
+    assert {i.concept_name for i in structured} == {i.concept_name for i in items}
+    # Prerequisite-first items appear before standard items they gate
+    order = [i.concept_name for i in structured]
+    if "Chain Rule" in order and "Integral" in order:
+        chain_pos = order.index("Chain Rule")
+        assert structured[chain_pos].review_type == "prerequisite_first"
+
+
+# ── E2E: review outcomes feed consolidation ──
+
+
+@pytest.mark.asyncio
+async def test_e2e_review_outcome_triggers_consolidation(db, user_id, course_id):
+    """Recalling the last weak prerequisite consolidates the parent concept."""
+    parent = KnowledgeNode(id=uuid.uuid4(), course_id=course_id, name="Quadratic Equations")
+    q = KnowledgeNode(id=uuid.uuid4(), course_id=course_id, name="Algebra Basics")
+    r = KnowledgeNode(id=uuid.uuid4(), course_id=course_id, name="Linear Equations")
+    for n in (parent, q, r):
+        db.add(n)
+    await db.flush()
+    db.add(KnowledgeEdge(source_id=parent.id, target_id=q.id, relation_type="prerequisite", weight=1.0))
+    db.add(KnowledgeEdge(source_id=parent.id, target_id=r.id, relation_type="prerequisite", weight=1.0))
+
+    # Q solidly mastered; R just below the 0.85 consolidation threshold; parent mid
+    db.add(ConceptMastery(user_id=user_id, knowledge_node_id=q.id, mastery_score=0.90,
+                          practice_count=5, correct_count=5, stability_days=10.0))
+    db.add(ConceptMastery(user_id=user_id, knowledge_node_id=r.id, mastery_score=0.84,
+                          practice_count=4, correct_count=3, stability_days=8.0))
+    db.add(ConceptMastery(user_id=user_id, knowledge_node_id=parent.id, mastery_score=0.50,
+                          practice_count=2, correct_count=1, stability_days=2.0))
+    await db.commit()
+
+    # Correct recall of R: 0.84 + 0.1·(1−0.84) ≈ 0.856 → crosses 0.85 → consolidate
+    await record_review_outcome(db, user_id, r.id, recalled_correctly=True)
+    await db.commit()
+
+    masteries = {
+        m.knowledge_node_id: m
+        for m in (await db.execute(
+            select(ConceptMastery).where(ConceptMastery.user_id == user_id)
+        )).scalars().all()
+    }
+    assert masteries[r.id].mastery_score >= 0.85
+    # Parent got the consolidation bonus (0.50 → 0.60)
+    assert masteries[parent.id].mastery_score == pytest.approx(0.60, abs=0.01)
+    # Mastered prerequisites get their review interval extended (×1.5)
+    assert masteries[q.id].stability_days == pytest.approx(15.0, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_e2e_review_outcome_updates_fsrs_schedule(db, user_id, course_id):
+    from datetime import datetime, timedelta, timezone
+
+    node = KnowledgeNode(id=uuid.uuid4(), course_id=course_id, name="Eigenvalue")
+    db.add(node)
+    await db.flush()
+    db.add(ConceptMastery(user_id=user_id, knowledge_node_id=node.id, mastery_score=0.5,
+                          practice_count=3, correct_count=2, wrong_count=1, stability_days=5.0,
+                          last_practiced_at=datetime.now(timezone.utc) - timedelta(days=6)))
+    await db.commit()
+
+    await record_review_outcome(db, user_id, node.id, recalled_correctly=True)
+    await db.commit()
+
+    m = (await db.execute(
+        select(ConceptMastery).where(ConceptMastery.knowledge_node_id == node.id)
+    )).scalar_one()
+    assert m.mastery_score > 0.5
+    assert m.stability_days > 5.0
+    assert m.next_review_at is not None
+    assert m.practice_count == 4


### PR DESCRIPTION
## Summary

Addresses the remaining LECTOR MVP checklist items from #39. Of the checklist, proactive review scheduling (`heartbeat_review_job` every 6h, `smart_review_trigger_job` every 4h in the scheduler engine) and session clustering (`lector_session.py`: warm-up → prerequisite-first → contrast pairs → interleaving → peak-end) already exist in the codebase. This PR fills the actual gaps.

## Changes

### 1. Interference threshold wired to settings (+ a hot-loop fix)

Factor 7 (proactive interference) compared against a hardcoded `0.6` even though `loom_interference_similarity_threshold` already exists in `config.py`. It now reads the setting, so the issue's "conceptual similarity threshold: 0.6" is configurable via `LOOM_INTERFERENCE_SIMILARITY_THRESHOLD`.

While there: the factor re-scanned **all** course edges per confused pair (`O(edges × pairs)` inside the per-node loop). The strongest `confused_with` weight per node is now collected in the single edge pass that already builds the adjacency maps.

### 2. Consolidation bonuses on review outcomes

`update_concept_mastery` (quiz path) triggers LOOM consolidation, but `record_review_outcome` (LECTOR review path) did not — so a *review recall* that completed a mastered prerequisite group never awarded the parent-concept bonus. `record_review_outcome` now calls `_consolidate_mastered_concepts` after the mastery update, making both practice paths consistent.

### 3. E2E test: practice → build mastery → verify review ordering

`tests/test_lector_e2e.py`, on real in-memory SQLite with real BKT/FSRS math (no mocks):

- 4 strong correct answers collapse one concept out of the review session; 2 wrong answers surface the failing concept with its confusion edge flagged (`high semantic interference`)
- the never-practiced dependent of a weak prerequisite ranks first with `prerequisite_first` review type and a named-prerequisite reason
- raising `LOOM_INTERFERENCE_SIMILARITY_THRESHOLD` above the edge weight removes the interference flag
- `build_structured_session` preserves the item set and keeps prerequisite-first typing
- a correct recall that pushes the last prerequisite across the 0.85 group threshold boosts the parent concept 0.50 → 0.60 and extends the group's review intervals ×1.5
- review outcomes update the FSRS schedule (stability growth, `next_review_at` set)

Existing `test_lector.py` mocks updated for the new settings key and the two extra queries on the outcome path.

## Tests

`test_lector_e2e.py` (5 new) + `test_lector.py` + `test_loom.py`: **65 passed, 4 skipped** locally (skips are the pre-existing `lector_analytics` import guard).

## Checklist mapping

- [x] Interference matrix integration (conceptual similarity threshold: 0.6) — now honors the configured threshold
- [x] Proactive review scheduling (background job) — already implemented (`heartbeat_review`, `smart_review_trigger` APScheduler jobs)
- [x] Session clustering — already implemented (`lector_session.py`); covered by the E2E test
- [x] Consolidation bonuses when prerequisite groups are mastered — now also fires on the review-outcome path
- [x] End-to-end test: practice → build mastery → verify review ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
