### PR TITLE
fix(cognitive-load): serialize weight tuning to stop concurrent update loss

### DIFF
--- a/apps/api/services/cognitive_load_tuning.py
+++ b/apps/api/services/cognitive_load_tuning.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import collections
 import logging
+import threading
 from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,12 @@ class _UserState(NamedTuple):
 
 # In-memory store: user_id (str) → _UserState
 _store: dict[str, _UserState] = {}
+
+# Concurrent chat sessions reach this module from FastAPI's threadpool, so
+# every read-modify-write on _store / windows / multipliers must be serialized:
+# unlocked, the eviction scan can hit "dict changed size during iteration" and
+# parallel multiplier updates lose decay/recovery steps (issue #37).
+_lock = threading.Lock()
 
 
 def _get_or_create(user_id: str) -> _UserState:
@@ -75,41 +82,45 @@ def update_and_get_multipliers(
 
     Returns a dict mapping signal name → multiplier (float in [MIN_WEIGHT_RATIO, 1.0]).
     For signals with no history yet the multiplier is 1.0 (no adjustment).
+
+    Thread-safe: concurrent updates for the same or different users are
+    serialized, so no decay/recovery step is ever lost.
     """
-    state = _get_or_create(str(user_id))
+    with _lock:
+        state = _get_or_create(str(user_id))
 
-    for signal_name, value in signals.items():
-        if not isinstance(value, (int, float)):
-            continue
-        if signal_name not in state.windows:
-            state.windows[signal_name] = collections.deque(maxlen=WINDOW_SIZE)
-            state.multipliers[signal_name] = 1.0
+        for signal_name, value in signals.items():
+            if not isinstance(value, (int, float)):
+                continue
+            if signal_name not in state.windows:
+                state.windows[signal_name] = collections.deque(maxlen=WINDOW_SIZE)
+                state.multipliers[signal_name] = 1.0
 
-        state.windows[signal_name].append(float(value))
+            state.windows[signal_name].append(float(value))
 
-        dq = state.windows[signal_name]
-        if len(dq) < 5:
-            # Need at least 5 data points before adjusting
-            continue
+            dq = state.windows[signal_name]
+            if len(dq) < 5:
+                # Need at least 5 data points before adjusting
+                continue
 
-        mean = sum(dq) / len(dq)
-        current = state.multipliers[signal_name]
+            mean = sum(dq) / len(dq)
+            current = state.multipliers[signal_name]
 
-        if mean >= HIGH_SIGNAL_THRESHOLD:
-            # Signal persistently high → dampen its weight contribution
-            new = max(MIN_WEIGHT_RATIO, current * WEIGHT_DECAY_FACTOR)
-            if new != current:
-                logger.debug(
-                    "cognitive_load_tuning: user=%s signal=%s mean=%.2f → multiplier %.3f → %.3f",
-                    user_id, signal_name, mean, current, new,
-                )
-            state.multipliers[signal_name] = new
-        else:
-            # Signal no longer elevated → slowly recover toward 1.0
-            new = min(MAX_WEIGHT_RATIO, current * RECOVERY_FACTOR)
-            state.multipliers[signal_name] = new
+            if mean >= HIGH_SIGNAL_THRESHOLD:
+                # Signal persistently high → dampen its weight contribution
+                new = max(MIN_WEIGHT_RATIO, current * WEIGHT_DECAY_FACTOR)
+                if new != current:
+                    logger.debug(
+                        "cognitive_load_tuning: user=%s signal=%s mean=%.2f → multiplier %.3f → %.3f",
+                        user_id, signal_name, mean, current, new,
+                    )
+                state.multipliers[signal_name] = new
+            else:
+                # Signal no longer elevated → slowly recover toward 1.0
+                new = min(MAX_WEIGHT_RATIO, current * RECOVERY_FACTOR)
+                state.multipliers[signal_name] = new
 
-    return dict(state.multipliers)
+        return dict(state.multipliers)
 
 
 def get_multipliers(user_id: str) -> dict[str, float]:
@@ -118,19 +129,21 @@ def get_multipliers(user_id: str) -> dict[str, float]:
     Returns an empty dict if no data has been recorded for this user yet
     (caller should treat missing keys as multiplier=1.0).
     """
-    state = _store.get(str(user_id))
-    if state is None:
-        return {}
-    return dict(state.multipliers)
+    with _lock:
+        state = _store.get(str(user_id))
+        if state is None:
+            return {}
+        return dict(state.multipliers)
 
 
 def reset_multipliers(user_id: str) -> None:
     """Reset all multipliers for a user to 1.0 (e.g. after a long break)."""
-    state = _store.get(str(user_id))
-    if state is None:
-        return
-    for key in state.multipliers:
-        state.multipliers[key] = 1.0
-    for dq in state.windows.values():
-        dq.clear()
+    with _lock:
+        state = _store.get(str(user_id))
+        if state is None:
+            return
+        for key in state.multipliers:
+            state.multipliers[key] = 1.0
+        for dq in state.windows.values():
+            dq.clear()
     logger.info("cognitive_load_tuning: reset multipliers for user=%s", user_id)

--- a/tests/test_cognitive_load_tuning.py
+++ b/tests/test_cognitive_load_tuning.py
@@ -1,0 +1,123 @@
+"""Tests for the cognitive load weight auto-tuner, including concurrent safety (issue #37).
+
+The tuner is reached from FastAPI's threadpool by concurrent chat sessions, so
+read-modify-write sequences on the in-memory store must not lose updates and
+the eviction scan must not race dict mutation.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from services import cognitive_load_tuning as tuning
+from services.cognitive_load_tuning import (
+    MIN_WEIGHT_RATIO,
+    WEIGHT_DECAY_FACTOR,
+    get_multipliers,
+    reset_multipliers,
+    update_and_get_multipliers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    with tuning._lock:
+        tuning._store.clear()
+    yield
+    with tuning._lock:
+        tuning._store.clear()
+
+
+# ── Sequential behavior ──
+
+
+def test_no_adjustment_below_min_samples():
+    for _ in range(4):
+        m = update_and_get_multipliers("u1", {"errors": 1.0})
+    assert m["errors"] == 1.0
+
+
+def test_decay_when_persistently_high():
+    # 6 high samples: window reaches 5 on the 5th, so exactly 2 decay steps
+    for _ in range(6):
+        m = update_and_get_multipliers("u1", {"errors": 1.0})
+    assert m["errors"] == pytest.approx(WEIGHT_DECAY_FACTOR ** 2)
+
+
+def test_decay_floor():
+    for _ in range(60):
+        m = update_and_get_multipliers("u1", {"errors": 1.0})
+    assert m["errors"] == pytest.approx(MIN_WEIGHT_RATIO)
+
+
+def test_recovery_when_signal_drops():
+    for _ in range(60):
+        update_and_get_multipliers("u1", {"errors": 1.0})
+    for _ in range(60):
+        m = update_and_get_multipliers("u1", {"errors": 0.0})
+    assert m["errors"] > MIN_WEIGHT_RATIO
+
+
+def test_reset_multipliers():
+    for _ in range(10):
+        update_and_get_multipliers("u1", {"errors": 1.0})
+    reset_multipliers("u1")
+    assert all(v == 1.0 for v in get_multipliers("u1").values())
+
+
+def test_non_numeric_signals_ignored():
+    m = update_and_get_multipliers("u1", {"errors": "high", "fatigue": 0.5})
+    assert "errors" not in m and "fatigue" in m
+
+
+# ── Concurrent safety (issue #37) ──
+
+
+def test_concurrent_same_signal_loses_no_decay_steps():
+    """6 total high samples from 2 threads must yield exactly 2 decay steps.
+
+    Without serialization, two threads can read the same multiplier and both
+    write current * 0.9, silently dropping one decay step.
+    """
+    def worker():
+        for _ in range(3):
+            update_and_get_multipliers("u1", {"errors": 1.0})
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        for f in [pool.submit(worker), pool.submit(worker)]:
+            f.result()
+
+    assert get_multipliers("u1")["errors"] == pytest.approx(WEIGHT_DECAY_FACTOR ** 2)
+
+
+def test_concurrent_distinct_signals_all_tracked():
+    """Each thread updates its own signal for the same user; none may vanish."""
+    def worker(signal):
+        for _ in range(6):
+            update_and_get_multipliers("u1", {signal: 1.0})
+
+    signals = [f"sig{i}" for i in range(8)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for f in [pool.submit(worker, s) for s in signals]:
+            f.result()
+
+    m = get_multipliers("u1")
+    assert set(m) == set(signals)
+    assert all(v == pytest.approx(WEIGHT_DECAY_FACTOR ** 2) for v in m.values())
+
+
+def test_concurrent_eviction_does_not_crash_or_overflow():
+    """480 distinct users from 8 threads cross the 200-user cap concurrently.
+
+    Without the lock, the eviction min() scan iterates the store while other
+    threads mutate it (RuntimeError) and parallel inserts overshoot the cap.
+    """
+    def worker(offset):
+        for i in range(60):
+            update_and_get_multipliers(f"user-{offset}-{i}", {"errors": 0.5})
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for f in [pool.submit(worker, o) for o in range(8)]:
+            f.result()  # Raises if any worker crashed
+
+    assert len(tuning._store) <= tuning._MAX_CACHE_SIZE


### PR DESCRIPTION
## Summary

Closes #37.

The cognitive-load weight auto-tuner is reached from FastAPI threadpool workers by concurrent chat sessions, but its in-memory store had no synchronization, producing exactly the data-loss class described in the issue:

1. **Lost tuning steps** — the per-signal read-modify-write (read current multiplier → apply decay/recovery factor → write back) could interleave across threads, so the second writer silently overwrote the first's adjustment.
2. **Eviction race** — the cache-cap eviction does a `min()` scan over the store; with another thread inserting/deleting users mid-scan this raises `RuntimeError: dictionary changed size during iteration`, and parallel inserts could overshoot the 200-user cap.

## Note on the issue text

The issue references an AgentKV read-modify-write in `cognitive_load_tuning.py` lines 65–176 with `SELECT ... FOR UPDATE` as a candidate fix. The tuner has since been rewritten as a pure in-memory module (sliding window + multipliers dict), so there is no DB row to lock anymore — but the same race class moved into the process-local store. The fix targets the current implementation.

## Fix

A module-level `threading.Lock` serializes `update_and_get_multipliers`, `get_multipliers`, and `reset_multipliers`. The critical sections are pure in-memory arithmetic over small dicts (microseconds), so contention is negligible; no lock is held across any I/O.

## Tests

First test coverage for this module — `tests/test_cognitive_load_tuning.py` (10 tests):

**Sequential behavior**: no adjustment below 5 samples; exactly 2 decay steps after 6 persistently-high samples (`0.9²`); decay floor at 0.40; recovery after the signal drops; reset; non-numeric signals ignored.

**Concurrent safety** (the issue's acceptance criterion):
- 2 threads sharing one signal must produce exactly the sequential number of decay steps — a lost update yields `0.9` instead of `0.81` and fails
- 8 threads updating 8 distinct signals for one user — every signal must survive with the exact sequential multiplier
- 480 distinct users from 8 threads crossing the 200-user eviction cap — must neither raise nor overflow the cap

Local run: `test_cognitive_load_tuning.py + test_cognitive_load.py + test_cognitive_load_calibrator.py` → **42 passed**.

## Acceptance criteria

- [x] Concurrent weight updates don't lose data
- [x] Unit test verifies concurrent safety
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
