### PR TITLE
test(cognitive-load): pin cache eviction behavior for both in-memory caches

### DIFF
--- a/tests/test_cognitive_load_cache_bounds.py
+++ b/tests/test_cognitive_load_cache_bounds.py
@@ -1,0 +1,114 @@
+"""Cache eviction tests for the cognitive-load in-memory caches (issue #30).
+
+Both caches already enforce a hard bound in code; these tests pin that
+behavior so a regression back to unbounded growth fails loudly:
+
+- ``cognitive_load_nlp._analysis_cache`` — capped at 500, evicts the oldest
+  half when full
+- ``cognitive_load_calibrator._cache`` — capped at 200, evicts the
+  least-active (lowest ``message_count``) baseline
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from services import cognitive_load_nlp as nlp
+from services import cognitive_load_calibrator as calibrator
+from services.cognitive_load_nlp import analyze_student_affect
+from services.cognitive_load_calibrator import StudentBaseline, get_or_create_baseline
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches(monkeypatch):
+    # Shrink the caps so eviction triggers in a handful of calls — the
+    # eviction logic reads the module attribute at call time, so behavior
+    # is identical to the production 500/200 values.
+    monkeypatch.setattr(nlp, "_MAX_CACHE_SIZE", 10)
+    monkeypatch.setattr(calibrator, "_MAX_CACHE_SIZE", 10)
+    nlp._analysis_cache.clear()
+    calibrator._cache.clear()
+    yield
+    nlp._analysis_cache.clear()
+    calibrator._cache.clear()
+
+
+def _llm_unavailable():
+    """Force analyze_student_affect down the deterministic keyword fallback."""
+    return patch(
+        "services.llm.router.get_llm_client",
+        side_effect=RuntimeError("no llm in test"),
+    )
+
+
+# ── NLP analysis cache ──
+
+
+@pytest.mark.asyncio
+async def test_nlp_cache_never_exceeds_max_size():
+    with _llm_unavailable():
+        for i in range(nlp._MAX_CACHE_SIZE + 40):
+            await analyze_student_affect(f"unique message number {i}")
+
+    assert len(nlp._analysis_cache) <= nlp._MAX_CACHE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_nlp_cache_eviction_drops_oldest_keeps_newest():
+    with _llm_unavailable():
+        for i in range(nlp._MAX_CACHE_SIZE + 1):
+            await analyze_student_affect(f"unique message number {i}")
+
+    # Crossing the cap flushes the oldest half; the newest entry must survive
+    assert f"unique message number {nlp._MAX_CACHE_SIZE}"[:200] in nlp._analysis_cache
+    assert "unique message number 0"[:200] not in nlp._analysis_cache
+    assert len(nlp._analysis_cache) <= nlp._MAX_CACHE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_nlp_cache_hit_skips_reanalysis():
+    with _llm_unavailable():
+        first = await analyze_student_affect("same message")
+    # No LLM patch on the second call: a cache hit must return before any
+    # LLM/fallback work happens, so the result object is identical
+    second = await analyze_student_affect("same message")
+    assert second is first
+    assert len(nlp._analysis_cache) == 1
+
+
+# ── Calibrator baseline cache ──
+
+
+def test_calibrator_cache_never_exceeds_max_size():
+    for _ in range(calibrator._MAX_CACHE_SIZE + 50):
+        get_or_create_baseline(uuid.uuid4())
+
+    assert len(calibrator._cache) <= calibrator._MAX_CACHE_SIZE
+
+
+def test_calibrator_evicts_least_active_baseline():
+    # Fill the cache; give everyone some activity except one idle user
+    idle_user = uuid.uuid4()
+    get_or_create_baseline(idle_user).message_count = 0
+    active_ids = [uuid.uuid4() for _ in range(calibrator._MAX_CACHE_SIZE - 1)]
+    for uid in active_ids:
+        get_or_create_baseline(uid).message_count = 10
+
+    assert len(calibrator._cache) == calibrator._MAX_CACHE_SIZE
+
+    # One more user forces eviction of the least-active baseline
+    newcomer = uuid.uuid4()
+    get_or_create_baseline(newcomer)
+
+    assert str(idle_user) not in calibrator._cache
+    assert str(newcomer) in calibrator._cache
+    assert len(calibrator._cache) == calibrator._MAX_CACHE_SIZE
+
+
+def test_calibrator_returns_same_instance_for_same_user():
+    uid = uuid.uuid4()
+    a = get_or_create_baseline(uid)
+    b = get_or_create_baseline(uid)
+    assert a is b
+    assert isinstance(a, StudentBaseline)


### PR DESCRIPTION
﻿## Summary

Addresses the remaining acceptance item on #30.

The two caches named in the issue already enforce hard bounds in the current code (the issue predates the fix): `cognitive_load_nlp._analysis_cache` caps at 500 and flushes the oldest half when full (under an `asyncio.Lock`), and `cognitive_load_calibrator._cache` caps at 200 and evicts the least-active (lowest `message_count`) baseline. So of the acceptance criteria, the first two are already satisfied — what was missing was **the unit test verifying eviction behavior**, without which a regression back to unbounded growth would land silently.

## Changes

`tests/test_cognitive_load_cache_bounds.py` (6 tests):

**NLP analysis cache**
- never exceeds its cap under sustained distinct messages
- crossing the cap drops the oldest entries and keeps the newest
- a cache hit returns the cached object without re-analysis

**Calibrator baseline cache**
- never exceeds its cap
- eviction removes exactly the least-active baseline and admits the newcomer
- same user always receives the same baseline instance

The fixture monkeypatches the caps small (the eviction logic reads the module attribute at call time), keeping the suite at ~6s instead of ~3min with production-size caps.

## Tests

`test_cognitive_load_cache_bounds.py + test_cognitive_load_calibrator.py`: **23 passed** locally.

## Acceptance criteria

- [x] Both caches have a defined max size — already in code (500 / 200)
- [x] Eviction happens automatically when max size is reached — already in code
- [x] Existing tests pass
- [x] Add a unit test verifying cache eviction behavior — this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
