### PR TITLE
test(web): cover 429 rate-limit retry in the API client

### DIFF
--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -97,6 +97,18 @@ describe("request", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  it("retries on 429 rate limiting", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ detail: "Rate limit exceeded" }, 429))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const promise = request<{ ok: boolean }>("/health");
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("retries on network errors (TypeError)", async () => {
     mockFetch
       .mockRejectedValueOnce(new TypeError("Failed to fetch"))


### PR DESCRIPTION
﻿## Summary

Closes #5.

`client.test.ts` already covers nearly everything the issue asked for — GET + JSON parsing, 204, 4xx without retry, retry on 5xx, retry on network `TypeError`, and exhausting `MAX_RETRIES` (see triage note on the issue). The one branch of `isRetryable()` (`status >= 500 || status === 429`) still untested was **429 rate limiting**.

## Changes

One test: a 429 response is retried with backoff and succeeds on the second attempt, following the existing fake-timers pattern in the file.

## Results

`npx vitest run src/lib/api/client.test.ts`: **13 passed** locally (12 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
