### PR TITLE
fix(web): add missing 'summary' block to exhaustive BlockType records

### DIFF
--- a/apps/web/src/app/setup/template-step.tsx
+++ b/apps/web/src/app/setup/template-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { GraduationCap, Compass, Clock, Shield, BookOpen, Brain, BarChart3, ListChecks, HelpCircle, Layers, AlertTriangle, Lightbulb, FileText } from "lucide-react";
+import { GraduationCap, Compass, Clock, Shield, BookOpen, Brain, BarChart3, ListChecks, HelpCircle, Layers, AlertTriangle, Lightbulb, FileText, Newspaper } from "lucide-react";
 import { TEMPLATE_LIST, LEARNING_MODE_LIST } from "@/lib/block-system/templates";
 import type { LearningMode } from "@/lib/block-system/types";
 import type { BlockType } from "@/lib/block-system/types";
@@ -17,6 +17,7 @@ const BLOCK_ICONS: Record<BlockType, typeof BookOpen> = {
   wrong_answers: AlertTriangle,
   forecast: BarChart3,
   agent_insight: Lightbulb,
+  summary: Newspaper,
 };
 
 const MODE_ICONS: Record<LearningMode, typeof GraduationCap> = {

--- a/apps/web/src/lib/block-system/layout-storage.ts
+++ b/apps/web/src/lib/block-system/layout-storage.ts
@@ -44,6 +44,7 @@ const BLOCK_DEFAULT_SIZES: Record<BlockType, BlockSize> = {
   wrong_answers: "medium",
   forecast: "small",
   agent_insight: "full",
+  summary: "small",
 };
 
 let fallbackBlockIdCounter = 0;


### PR DESCRIPTION
## What

The production Docker build (`npm run build`) fails during `tsc` type-checking because the `summary` block type (added to the `BlockType` union and `BLOCK_REGISTRY`) was never added to two other `Record<BlockType, ...>` maps that exhaustively cover all block types.

## Why

`Record<BlockType, T>` requires a value for every member of the union. Missing keys = type error = build failure. This breaks `docker compose build` / `npm run build` out of the box after a fresh clone.

Build error:
```
./src/app/setup/template-step.tsx:8:7
Type error: Property 'summary' is missing in type '{ notes: ...; ... 9 more ...; agent_insight: ...; }'
but required in type 'Record<BlockType, ...>'.
```

## Changes

- `apps/web/src/app/setup/template-step.tsx` — added `summary: Newspaper` to `BLOCK_ICONS` (+ import). This is the error in the build log.
- `apps/web/src/lib/block-system/layout-storage.ts` — added `summary: "small"` to `BLOCK_DEFAULT_SIZES`. Same latent bug; would fail immediately after the first fix.

Values match `BLOCK_REGISTRY` (icon `Newspaper`, default size `"small"`).

## Checklist

- [x] Tests pass
- [x] No new `any` types in TypeScript
- [x] No i18n keys needed (no new user-facing strings — just icon/size entries)
- [x] No new tests needed (pure type-completeness fix)
- [x] No hardcoded secrets or API keys